### PR TITLE
feat: LinkedList 구현

### DIFF
--- a/src/main/java/org/example/linkedlist/LinkedList.java
+++ b/src/main/java/org/example/linkedlist/LinkedList.java
@@ -59,6 +59,16 @@ public class LinkedList<E> {
         node.setValue(element);
     }
 
+    public E removeFirst() {
+        checkElementExists();
+        final E removedValue = head.getValue();
+        final Node<E> nodeToBeHead = head.next;
+        nodeToBeHead.prev = Node.ofEmpty();
+        head = nodeToBeHead;
+        numberOfElements--;
+        return removedValue;
+    }
+
     public E getFirst() {
         checkElementExists();
         return head.getValue();

--- a/src/main/java/org/example/linkedlist/LinkedList.java
+++ b/src/main/java/org/example/linkedlist/LinkedList.java
@@ -15,13 +15,36 @@ public class LinkedList<E> {
     public void addFirst(final E element) {
         final Node<E> nodeToAdd = new Node<>(element, head);
         head = nodeToAdd;
-        if (head.equals(Node.ofEmpty())) {
+        if (isEmpty()) {
             tail = nodeToAdd;
         }
         numberOfElements++;
     }
 
+    public void addLast(final E element) {
+        final Node<E> nodeToAdd = new Node<>(element, Node.ofEmpty());
+        if (isEmpty()) {
+            head = nodeToAdd;
+        } else {
+            tail.linkNext(nodeToAdd);
+        }
+        tail = nodeToAdd;
+        numberOfElements++;
+    }
+
     public E getFirst() {
         return head.getValue();
+    }
+
+    public E getLast() {
+        return tail.getValue();
+    }
+
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    public int size() {
+        return numberOfElements;
     }
 }

--- a/src/main/java/org/example/linkedlist/LinkedList.java
+++ b/src/main/java/org/example/linkedlist/LinkedList.java
@@ -69,6 +69,16 @@ public class LinkedList<E> {
         return removedValue;
     }
 
+    public E removeLast() {
+        checkElementExists();
+        final E removedValue = tail.getValue();
+        final Node<E> nodeToBeTail = tail.prev;
+        nodeToBeTail.next = Node.ofEmpty();
+        tail = nodeToBeTail;
+        numberOfElements--;
+        return removedValue;
+    }
+
     public E getFirst() {
         checkElementExists();
         return head.getValue();

--- a/src/main/java/org/example/linkedlist/LinkedList.java
+++ b/src/main/java/org/example/linkedlist/LinkedList.java
@@ -54,6 +54,11 @@ public class LinkedList<E> {
         numberOfElements++;
     }
 
+    public void set(final int index, final E element) {
+        final Node<E> node = getNode(index);
+        node.setValue(element);
+    }
+
     public E getFirst() {
         checkElementExists();
         return head.getValue();

--- a/src/main/java/org/example/linkedlist/LinkedList.java
+++ b/src/main/java/org/example/linkedlist/LinkedList.java
@@ -36,6 +36,24 @@ public class LinkedList<E> {
         numberOfElements++;
     }
 
+    public void add(final int index, final E element) {
+        if (index == 0) {
+            addFirst(element);
+            return;
+        }
+        if (index == size()) {
+            addLast(element);
+            return;
+        }
+
+        final Node<E> old = getNode(index);
+        final Node<E> prev = old.prev;
+        final Node<E> nodeToAdd = new Node<>(element, prev, old);
+        prev.next = nodeToAdd;
+        old.prev = nodeToAdd;
+        numberOfElements++;
+    }
+
     public E getFirst() {
         checkElementExists();
         return head.getValue();
@@ -47,6 +65,19 @@ public class LinkedList<E> {
     }
 
     public E get(final int index) {
+        final Node<E> found = getNode(index);
+        return found.getValue();
+    }
+
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    public int size() {
+        return numberOfElements;
+    }
+
+    private Node<E> getNode(final int index) {
         checkIndex(index);
         Node<E> current;
         if (index < size() / 2) {
@@ -60,16 +91,7 @@ public class LinkedList<E> {
                 current = current.prev;
             }
         }
-
-        return current.getValue();
-    }
-
-    public boolean isEmpty() {
-        return size() == 0;
-    }
-
-    public int size() {
-        return numberOfElements;
+        return current;
     }
 
     private void checkElementExists() {

--- a/src/main/java/org/example/linkedlist/LinkedList.java
+++ b/src/main/java/org/example/linkedlist/LinkedList.java
@@ -79,6 +79,24 @@ public class LinkedList<E> {
         return removedValue;
     }
 
+    public E remove(final int index) {
+        if (index == 0) {
+            return removeFirst();
+        }
+        if (index == size() - 1) {
+            return removeLast();
+        }
+
+        final Node<E> removedNode = getNode(index);
+        final E removedValue = removedNode.getValue();
+        final Node<E> prevToRemoved = removedNode.prev;
+        final Node<E> nextToRemoved = removedNode.next;
+        prevToRemoved.next = nextToRemoved;
+        nextToRemoved.prev = prevToRemoved;
+        numberOfElements--;
+        return removedValue;
+    }
+
     public E getFirst() {
         checkElementExists();
         return head.getValue();

--- a/src/main/java/org/example/linkedlist/LinkedList.java
+++ b/src/main/java/org/example/linkedlist/LinkedList.java
@@ -16,15 +16,17 @@ public class LinkedList<E> {
 
     public void addFirst(final E element) {
         final Node<E> nodeToAdd = new Node<>(element, head);
-        head = nodeToAdd;
         if (isEmpty()) {
             tail = nodeToAdd;
+        } else {
+            head.prev = nodeToAdd;
         }
+        head = nodeToAdd;
         numberOfElements++;
     }
 
     public void addLast(final E element) {
-        final Node<E> nodeToAdd = new Node<>(element, Node.ofEmpty());
+        final Node<E> nodeToAdd = new Node<>(element, tail, Node.ofEmpty());
         if (isEmpty()) {
             head = nodeToAdd;
         } else {
@@ -46,10 +48,19 @@ public class LinkedList<E> {
 
     public E get(final int index) {
         checkIndex(index);
-        Node<E> current = head;
-        for (int i = 0; i < index; i++) {
-            current = current.next;
+        Node<E> current;
+        if (index < size() / 2) {
+            current = head;
+            for (int i = 0; i < index; i++) {
+                current = current.next;
+            }
+        } else {
+            current = tail;
+            for (int i = size() - 1; i > index; i--) {
+                current = current.prev;
+            }
         }
+
         return current.getValue();
     }
 

--- a/src/main/java/org/example/linkedlist/LinkedList.java
+++ b/src/main/java/org/example/linkedlist/LinkedList.java
@@ -1,0 +1,27 @@
+package org.example.linkedlist;
+
+public class LinkedList<E> {
+
+    private Node<E> head;
+    private Node<E> tail;
+    private int numberOfElements;
+
+    public LinkedList() {
+        this.head = Node.ofEmpty();
+        this.tail = Node.ofEmpty();
+        this.numberOfElements = 0;
+    }
+
+    public void addFirst(final E element) {
+        final Node<E> nodeToAdd = new Node<>(element, head);
+        head = nodeToAdd;
+        if (head.equals(Node.ofEmpty())) {
+            tail = nodeToAdd;
+        }
+        numberOfElements++;
+    }
+
+    public E getFirst() {
+        return head.getValue();
+    }
+}

--- a/src/main/java/org/example/linkedlist/LinkedList.java
+++ b/src/main/java/org/example/linkedlist/LinkedList.java
@@ -1,5 +1,7 @@
 package org.example.linkedlist;
 
+import java.util.NoSuchElementException;
+
 public class LinkedList<E> {
 
     private Node<E> head;
@@ -26,18 +28,29 @@ public class LinkedList<E> {
         if (isEmpty()) {
             head = nodeToAdd;
         } else {
-            tail.linkNext(nodeToAdd);
+            tail.next = nodeToAdd;
         }
         tail = nodeToAdd;
         numberOfElements++;
     }
 
     public E getFirst() {
+        checkElementExists();
         return head.getValue();
     }
 
     public E getLast() {
+        checkElementExists();
         return tail.getValue();
+    }
+
+    public E get(final int index) {
+        checkIndex(index);
+        Node<E> current = head;
+        for (int i = 0; i < index; i++) {
+            current = current.next;
+        }
+        return current.getValue();
     }
 
     public boolean isEmpty() {
@@ -46,5 +59,17 @@ public class LinkedList<E> {
 
     public int size() {
         return numberOfElements;
+    }
+
+    private void checkElementExists() {
+        if (isEmpty()) {
+            throw new NoSuchElementException();
+        }
+    }
+
+    private void checkIndex(final int index) {
+        if (index < 0 || size() <= index) {
+            throw new IndexOutOfBoundsException();
+        }
     }
 }

--- a/src/main/java/org/example/linkedlist/Node.java
+++ b/src/main/java/org/example/linkedlist/Node.java
@@ -16,6 +16,10 @@ public class Node<T> {
         return (Node<T>) EMPTY_NODE;
     }
 
+    public void linkNext(final Node<T> next) {
+        this.next = next;
+    }
+
     public T getValue() {
         return value;
     }

--- a/src/main/java/org/example/linkedlist/Node.java
+++ b/src/main/java/org/example/linkedlist/Node.java
@@ -5,22 +5,18 @@ public class Node<T> {
     private static final Node<Object> EMPTY_NODE = new Node<>(null, null);
 
     private final T value;
-    private Node<T> next;
+    Node<T> next;
 
     public Node(final T value, final Node<T> next) {
         this.value = value;
         this.next = next;
     }
 
-    public static <T> Node<T> ofEmpty() {
+    static <T> Node<T> ofEmpty() {
         return (Node<T>) EMPTY_NODE;
     }
 
-    public void linkNext(final Node<T> next) {
-        this.next = next;
-    }
-
-    public T getValue() {
+    T getValue() {
         return value;
     }
 }

--- a/src/main/java/org/example/linkedlist/Node.java
+++ b/src/main/java/org/example/linkedlist/Node.java
@@ -4,7 +4,7 @@ public class Node<T> {
 
     private static final Node<Object> EMPTY_NODE = new Node<>(null, null);
 
-    private final T value;
+    private T value;
     Node<T> prev;
     Node<T> next;
 
@@ -24,5 +24,9 @@ public class Node<T> {
 
     T getValue() {
         return value;
+    }
+
+    void setValue(final T value) {
+        this.value = value;
     }
 }

--- a/src/main/java/org/example/linkedlist/Node.java
+++ b/src/main/java/org/example/linkedlist/Node.java
@@ -1,0 +1,22 @@
+package org.example.linkedlist;
+
+public class Node<T> {
+
+    private static final Node<Object> EMPTY_NODE = new Node<>(null, null);
+
+    private final T value;
+    private Node<T> next;
+
+    public Node(final T value, final Node<T> next) {
+        this.value = value;
+        this.next = next;
+    }
+
+    public static <T> Node<T> ofEmpty() {
+        return (Node<T>) EMPTY_NODE;
+    }
+
+    public T getValue() {
+        return value;
+    }
+}

--- a/src/main/java/org/example/linkedlist/Node.java
+++ b/src/main/java/org/example/linkedlist/Node.java
@@ -5,10 +5,16 @@ public class Node<T> {
     private static final Node<Object> EMPTY_NODE = new Node<>(null, null);
 
     private final T value;
+    Node<T> prev;
     Node<T> next;
 
     public Node(final T value, final Node<T> next) {
+        this(value, ofEmpty(), next);
+    }
+
+    public Node(final T value, final Node<T> prev, final Node<T> next) {
         this.value = value;
+        this.prev = prev;
         this.next = next;
     }
 

--- a/src/test/java/org/example/linkedlist/LinkedListTest.java
+++ b/src/test/java/org/example/linkedlist/LinkedListTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import java.util.NoSuchElementException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -67,11 +68,11 @@ class LinkedListTest {
         @Test
         void throwsException_whenIndexOutOfBound() {
             // given
-            final LinkedList<String> linkedList = new LinkedList<>();
+            final LinkedList<String> emptyList = new LinkedList<>();
 
             // when & then
             assertThatExceptionOfType(IndexOutOfBoundsException.class)
-                    .isThrownBy(() -> linkedList.get(0));
+                    .isThrownBy(() -> emptyList.get(0));
         }
 
     }
@@ -99,11 +100,11 @@ class LinkedListTest {
         @Test
         void throwsException_whenIndexOutOfBound() {
             // given
-            final LinkedList<String> linkedList = new LinkedList<>();
+            final LinkedList<String> emptyList = new LinkedList<>();
 
             // when & then
             assertThatExceptionOfType(IndexOutOfBoundsException.class)
-                    .isThrownBy(() -> linkedList.add(1, "data"));
+                    .isThrownBy(() -> emptyList.add(1, "data"));
         }
     }
 
@@ -130,11 +131,44 @@ class LinkedListTest {
         @Test
         void throwsException_whenIndexOutOfBound() {
             // given
-            final LinkedList<String> linkedList = new LinkedList<>();
+            final LinkedList<String> emptyList = new LinkedList<>();
 
             // when & then
             assertThatExceptionOfType(IndexOutOfBoundsException.class)
-                    .isThrownBy(() -> linkedList.set(0, "data"));
+                    .isThrownBy(() -> emptyList.set(0, "data"));
+        }
+    }
+
+    @DisplayName("맨 앞의 원소 삭제")
+    @Nested
+    class removeFirst {
+
+        @DisplayName("맨 앞의 원소를 삭제한다.")
+        @Test
+        void success() {
+            // given
+            final LinkedList<String> linkedList = new LinkedList<>();
+            linkedList.addFirst("data");
+
+            // when
+            final String removed = linkedList.removeFirst();
+
+            // then
+            assertAll(
+                    () -> assertThat(removed).isEqualTo("data"),
+                    () -> assertThat(linkedList.isEmpty()).isTrue()
+            );
+        }
+
+        @DisplayName("원소가 존재하지 않으면 예외가 발생한다.")
+        @Test
+        void throwsException_whenNoElement() {
+            // given
+            final LinkedList<String> emptyList = new LinkedList<>();
+
+            // when & then
+            assertThatExceptionOfType(NoSuchElementException.class)
+                    .isThrownBy(emptyList::removeFirst);
         }
     }
 }

--- a/src/test/java/org/example/linkedlist/LinkedListTest.java
+++ b/src/test/java/org/example/linkedlist/LinkedListTest.java
@@ -1,6 +1,7 @@
 package org.example.linkedlist;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,10 +15,30 @@ class LinkedListTest {
         final LinkedList<String> linkedList = new LinkedList<>();
 
         // when
-        final String addedValue = "data";
-        linkedList.addFirst(addedValue);
+        linkedList.addFirst("data1");
+        linkedList.addFirst("data2");
 
         // then
-        assertThat(linkedList.getFirst()).isEqualTo(addedValue);
+        assertAll(
+                () -> assertThat(linkedList.getFirst()).isEqualTo("data2"),
+                () -> assertThat(linkedList.size()).isEqualTo(2)
+        );
+    }
+
+    @DisplayName("리스트 맨 끝에 원소를 추가한다.")
+    @Test
+    void addLast() {
+        // given
+        final LinkedList<String> linkedList = new LinkedList<>();
+
+        // when
+        linkedList.addLast("data1");
+        linkedList.addLast("data2");
+
+        // then
+        assertAll(
+                () -> assertThat(linkedList.getLast()).isEqualTo("data2"),
+                () -> assertThat(linkedList.size()).isEqualTo(2)
+        );
     }
 }

--- a/src/test/java/org/example/linkedlist/LinkedListTest.java
+++ b/src/test/java/org/example/linkedlist/LinkedListTest.java
@@ -73,5 +73,37 @@ class LinkedListTest {
             assertThatExceptionOfType(IndexOutOfBoundsException.class)
                     .isThrownBy(() -> linkedList.get(0));
         }
+
+    }
+
+    @DisplayName("특정 위치 원소 삽입")
+    @Nested
+    class add {
+
+        @DisplayName("특정 위치에 원소를 추가한다.")
+        @Test
+        void success() {
+            // given
+            final LinkedList<String> linkedList = new LinkedList<>();
+            linkedList.addLast("data1");
+            linkedList.addLast("data2");
+
+            // when
+            linkedList.add(1, "data3");
+
+            // then
+            assertThat(linkedList.get(1)).isEqualTo("data3");
+        }
+
+        @DisplayName("인덱스가 범위를 벗어나면 예외가 발생한다.")
+        @Test
+        void throwsException_whenIndexOutOfBound() {
+            // given
+            final LinkedList<String> linkedList = new LinkedList<>();
+
+            // when & then
+            assertThatExceptionOfType(IndexOutOfBoundsException.class)
+                    .isThrownBy(() -> linkedList.add(1, "data"));
+        }
     }
 }

--- a/src/test/java/org/example/linkedlist/LinkedListTest.java
+++ b/src/test/java/org/example/linkedlist/LinkedListTest.java
@@ -1,0 +1,23 @@
+package org.example.linkedlist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class LinkedListTest {
+
+    @DisplayName("리스트 맨 앞에 원소를 추가한다.")
+    @Test
+    void addFirst() {
+        // given
+        final LinkedList<String> linkedList = new LinkedList<>();
+
+        // when
+        final String addedValue = "data";
+        linkedList.addFirst(addedValue);
+
+        // then
+        assertThat(linkedList.getFirst()).isEqualTo(addedValue);
+    }
+}

--- a/src/test/java/org/example/linkedlist/LinkedListTest.java
+++ b/src/test/java/org/example/linkedlist/LinkedListTest.java
@@ -106,4 +106,35 @@ class LinkedListTest {
                     .isThrownBy(() -> linkedList.add(1, "data"));
         }
     }
+
+    @DisplayName("특정 위치 원소 변경")
+    @Nested
+    class set {
+
+        @DisplayName("특정 위치의 원소를 변경한다.")
+        @Test
+        void success() {
+            // given
+            final LinkedList<String> linkedList = new LinkedList<>();
+            linkedList.addLast("data1");
+            linkedList.addLast("data2");
+
+            // when
+            linkedList.set(1, "changed");
+
+            // then
+            assertThat(linkedList.getLast()).isEqualTo("changed");
+        }
+
+        @DisplayName("인덱스가 범위를 벗어나면 예외가 발생한다.")
+        @Test
+        void throwsException_whenIndexOutOfBound() {
+            // given
+            final LinkedList<String> linkedList = new LinkedList<>();
+
+            // when & then
+            assertThatExceptionOfType(IndexOutOfBoundsException.class)
+                    .isThrownBy(() -> linkedList.set(0, "data"));
+        }
+    }
 }

--- a/src/test/java/org/example/linkedlist/LinkedListTest.java
+++ b/src/test/java/org/example/linkedlist/LinkedListTest.java
@@ -1,14 +1,16 @@
 package org.example.linkedlist;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class LinkedListTest {
 
-    @DisplayName("리스트 맨 앞에 원소를 추가한다.")
+    @DisplayName("맨 앞에 원소를 추가한다.")
     @Test
     void addFirst() {
         // given
@@ -25,7 +27,7 @@ class LinkedListTest {
         );
     }
 
-    @DisplayName("리스트 맨 끝에 원소를 추가한다.")
+    @DisplayName("맨 끝에 원소를 추가한다.")
     @Test
     void addLast() {
         // given
@@ -40,5 +42,36 @@ class LinkedListTest {
                 () -> assertThat(linkedList.getLast()).isEqualTo("data2"),
                 () -> assertThat(linkedList.size()).isEqualTo(2)
         );
+    }
+
+    @DisplayName("특정 위치 원소 반환")
+    @Nested
+    class get {
+
+        @DisplayName("특정 위치의 원소를 반환한다.")
+        @Test
+        void success() {
+            // given
+            final LinkedList<String> linkedList = new LinkedList<>();
+            linkedList.addLast("data1");
+            linkedList.addLast("data2");
+
+            // when
+            final String found = linkedList.get(1);
+
+            // then
+            assertThat(found).isEqualTo("data2");
+        }
+
+        @DisplayName("인덱스가 범위를 벗어나면 예외가 발생한다.")
+        @Test
+        void throwsException_whenIndexOutOfBound() {
+            // given
+            final LinkedList<String> linkedList = new LinkedList<>();
+
+            // when & then
+            assertThatExceptionOfType(IndexOutOfBoundsException.class)
+                    .isThrownBy(() -> linkedList.get(0));
+        }
     }
 }

--- a/src/test/java/org/example/linkedlist/LinkedListTest.java
+++ b/src/test/java/org/example/linkedlist/LinkedListTest.java
@@ -148,15 +148,16 @@ class LinkedListTest {
         void success() {
             // given
             final LinkedList<String> linkedList = new LinkedList<>();
-            linkedList.addFirst("data");
+            linkedList.addLast("data1");
+            linkedList.addLast("data2");
 
             // when
             final String removed = linkedList.removeFirst();
 
             // then
             assertAll(
-                    () -> assertThat(removed).isEqualTo("data"),
-                    () -> assertThat(linkedList.isEmpty()).isTrue()
+                    () -> assertThat(removed).isEqualTo("data1"),
+                    () -> assertThat(linkedList.size()).isOne()
             );
         }
 
@@ -169,6 +170,40 @@ class LinkedListTest {
             // when & then
             assertThatExceptionOfType(NoSuchElementException.class)
                     .isThrownBy(emptyList::removeFirst);
+        }
+    }
+
+    @DisplayName("맨 뒤의 원소 삭제")
+    @Nested
+    class removeLast {
+
+        @DisplayName("맨 뒤의 원소를 삭제한다.")
+        @Test
+        void success() {
+            // given
+            final LinkedList<String> linkedList = new LinkedList<>();
+            linkedList.addLast("data1");
+            linkedList.addLast("data2");
+
+            // when
+            final String removed = linkedList.removeLast();
+
+            // then
+            assertAll(
+                    () -> assertThat(removed).isEqualTo("data2"),
+                    () -> assertThat(linkedList.size()).isOne()
+            );
+        }
+
+        @DisplayName("원소가 존재하지 않으면 예외가 발생한다.")
+        @Test
+        void throwsException_whenNoElement() {
+            // given
+            final LinkedList<String> emptyList = new LinkedList<>();
+
+            // when & then
+            assertThatExceptionOfType(NoSuchElementException.class)
+                    .isThrownBy(emptyList::removeLast);
         }
     }
 }

--- a/src/test/java/org/example/linkedlist/LinkedListTest.java
+++ b/src/test/java/org/example/linkedlist/LinkedListTest.java
@@ -206,4 +206,40 @@ class LinkedListTest {
                     .isThrownBy(emptyList::removeLast);
         }
     }
+
+    @DisplayName("특정 위치 원소 삭제")
+    @Nested
+    class remove {
+
+        @DisplayName("특정 위치의 원소를 삭제한다.")
+        @Test
+        void success() {
+            // given
+            final LinkedList<String> linkedList = new LinkedList<>();
+            linkedList.addLast("data1");
+            linkedList.addLast("data2");
+            linkedList.addLast("data3");
+
+            // when
+            final String removed = linkedList.remove(1);
+
+            // then
+            assertAll(
+                    () -> assertThat(removed).isEqualTo("data2"),
+                    () -> assertThat(linkedList.size()).isEqualTo(2)
+            );
+        }
+
+        @DisplayName("원소가 존재하지 않으면 예외가 발생한다.")
+        @Test
+        void throwsException_whenIndexOutOfBound() {
+            // given
+            final LinkedList<String> linkedList = new LinkedList<>();
+            linkedList.addLast("data");
+
+            // when & then
+            assertThatExceptionOfType(IndexOutOfBoundsException.class)
+                    .isThrownBy(() -> linkedList.remove(1));
+        }
+    }
 }


### PR DESCRIPTION
# Linked List

배열에 비해 삽입, 삭제에 효율적인 선형 자료구조
비연속적인 메모리 주소에 각각 위치한 `Node`들이 연결된 형태
각 `Node`들이 자신의 인접 `Node`의 주소를 알고 있음(참조하고 있음)

### 구현 구조
![image](https://github.com/YJGwon/implement-data-structures/assets/89305335/b9ccc293-97aa-4e8a-8cb3-d43185bd5567)
- pointer가 가리키는 node가 없음을 나타내는 singleton 객체 `EMPTY_NODE` 사용
- node 간 양방향 연결
    - 양 끝 삭제, 삽입 모두 O(1)
    - 조회 시 최대 O(원소 개수 / 2): 가운데를 기준으로 원소가 뒤쪽에 위치하면 뒤에서부터 탐색


### 시간 복잡도
- addFirst(e): O(1)
- addLast(e): O(1)
- add(index, e): node 탐색 O(N), 추가 O(1)
- get(index): O(N)
- set(index, e): node 탐색 O(N), 변경 O(1)
- removeFirst(): O(1)
- removeLast(): O(1)
- remove(index): node 탐색 O(N), 삭제 O(1)
