### PR TITLE
feat: Queue 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 
 - [LinkedList](https://github.com/YJGwon/implement-data-structures/pull/1)
 - [Stack](https://github.com/YJGwon/implement-data-structures/pull/2)
+- [Queue](https://github.com/YJGwon/implement-data-structures/pull/3)

--- a/src/main/java/org/example/queue/EmptyQueueException.java
+++ b/src/main/java/org/example/queue/EmptyQueueException.java
@@ -1,0 +1,4 @@
+package org.example.queue;
+
+public class EmptyQueueException extends RuntimeException {
+}

--- a/src/main/java/org/example/queue/FixedQueue.java
+++ b/src/main/java/org/example/queue/FixedQueue.java
@@ -1,0 +1,50 @@
+package org.example.queue;
+
+public class FixedQueue<E> implements Queue<E> {
+
+    private final E[] elements;
+    private int numberOfElements;
+    private int first;
+    private int last;
+
+    public FixedQueue(final int capacity) {
+        this.elements = (E[]) new Object[capacity];
+        this.numberOfElements = 0;
+        this.first = -1;
+        this.last = -1;
+    }
+
+    @Override
+    public void enqueue(final E element) {
+        checkSize();
+        last = (last + 1) % elements.length;
+        elements[last] = element;
+        numberOfElements++;
+    }
+
+    @Override
+    public E dequeue() {
+        return null;
+    }
+
+    @Override
+    public E peek() {
+        return null;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    @Override
+    public int size() {
+        return numberOfElements;
+    }
+
+    private void checkSize() {
+        if (size() == elements.length) {
+            throw new FullQueueException();
+        }
+    }
+}

--- a/src/main/java/org/example/queue/FixedQueue.java
+++ b/src/main/java/org/example/queue/FixedQueue.java
@@ -34,7 +34,8 @@ public class FixedQueue<E> implements Queue<E> {
 
     @Override
     public E peek() {
-        return null;
+        checkEmpty();
+        return elements[first];
     }
 
     @Override

--- a/src/main/java/org/example/queue/FixedQueue.java
+++ b/src/main/java/org/example/queue/FixedQueue.java
@@ -8,23 +8,28 @@ public class FixedQueue<E> implements Queue<E> {
     private int last;
 
     public FixedQueue(final int capacity) {
+        validateCapacity(capacity);
         this.elements = (E[]) new Object[capacity];
         this.numberOfElements = 0;
-        this.first = -1;
+        this.first = 0;
         this.last = -1;
     }
 
     @Override
     public void enqueue(final E element) {
         checkSize();
-        last = (last + 1) % elements.length;
+        last = stepForward(last);
         elements[last] = element;
         numberOfElements++;
     }
 
     @Override
     public E dequeue() {
-        return null;
+        checkEmpty();
+        final E removedElement = elements[first];
+        first = stepForward(first);
+        numberOfElements--;
+        return removedElement;
     }
 
     @Override
@@ -42,9 +47,25 @@ public class FixedQueue<E> implements Queue<E> {
         return numberOfElements;
     }
 
+    private void validateCapacity(final int capacity) {
+        if (capacity <= 0) {
+            throw new IllegalArgumentException("큐의 크기는 1 이상이어야 합니다.");
+        }
+    }
+
     private void checkSize() {
         if (size() == elements.length) {
             throw new FullQueueException();
         }
+    }
+
+    private void checkEmpty() {
+        if (isEmpty()) {
+            throw new EmptyQueueException();
+        }
+    }
+
+    private int stepForward(final int index) {
+        return (index + 1) % elements.length;
     }
 }

--- a/src/main/java/org/example/queue/FlexibleQueue.java
+++ b/src/main/java/org/example/queue/FlexibleQueue.java
@@ -37,7 +37,9 @@ public class FlexibleQueue<E> implements Queue<E> {
 
     @Override
     public E peek() {
-        return null;
+        checkEmpty();
+        final Node<E> head = tail.next;
+        return head.value;
     }
 
     @Override

--- a/src/main/java/org/example/queue/FlexibleQueue.java
+++ b/src/main/java/org/example/queue/FlexibleQueue.java
@@ -1,0 +1,61 @@
+package org.example.queue;
+
+public class FlexibleQueue<E> implements Queue<E> {
+
+    private Node<E> tail;
+    private int numberOfElements;
+
+    public FlexibleQueue() {
+        this.tail = Node.ofEmpty();
+        this.numberOfElements = 0;
+    }
+
+    @Override
+    public void enqueue(final E element) {
+        final Node<E> nodeToAdd = new Node<>(element, tail.next);
+        if (isEmpty()) {
+            nodeToAdd.next = nodeToAdd;
+        } else {
+            tail.next = nodeToAdd;
+        }
+        tail = nodeToAdd;
+        numberOfElements++;
+    }
+
+    @Override
+    public E dequeue() {
+        return null;
+    }
+
+    @Override
+    public E peek() {
+        return null;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    @Override
+    public int size() {
+        return numberOfElements;
+    }
+
+    private static class Node<E> {
+
+        private static final Node<Object> EMPTY_NODE = new Node<>(null, null);
+
+        final E value;
+        Node<E> next;
+
+        private Node(final E value, final Node<E> next) {
+            this.value = value;
+            this.next = next;
+        }
+
+        static <E> Node<E> ofEmpty() {
+            return (Node<E>) EMPTY_NODE;
+        }
+    }
+}

--- a/src/main/java/org/example/queue/FlexibleQueue.java
+++ b/src/main/java/org/example/queue/FlexibleQueue.java
@@ -24,7 +24,15 @@ public class FlexibleQueue<E> implements Queue<E> {
 
     @Override
     public E dequeue() {
-        return null;
+        checkEmpty();
+        final Node<E> removedNode = tail.next;
+        if (removedNode == tail) {
+            tail = Node.ofEmpty();
+        } else {
+            tail.next = removedNode.next;
+        }
+        numberOfElements--;
+        return removedNode.value;
     }
 
     @Override
@@ -40,6 +48,12 @@ public class FlexibleQueue<E> implements Queue<E> {
     @Override
     public int size() {
         return numberOfElements;
+    }
+
+    private void checkEmpty() {
+        if (isEmpty()) {
+            throw new EmptyQueueException();
+        }
     }
 
     private static class Node<E> {

--- a/src/main/java/org/example/queue/FullQueueException.java
+++ b/src/main/java/org/example/queue/FullQueueException.java
@@ -1,0 +1,4 @@
+package org.example.queue;
+
+public class FullQueueException extends RuntimeException {
+}

--- a/src/main/java/org/example/queue/Queue.java
+++ b/src/main/java/org/example/queue/Queue.java
@@ -1,0 +1,14 @@
+package org.example.queue;
+
+public interface Queue<E> {
+
+    void enqueue(E element);
+
+    E dequeue();
+
+    E peek();
+
+    boolean isEmpty();
+
+    int size();
+}

--- a/src/test/java/org/example/queue/FixedQueueTest.java
+++ b/src/test/java/org/example/queue/FixedQueueTest.java
@@ -1,0 +1,41 @@
+package org.example.queue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class FixedQueueTest {
+
+    @DisplayName("원소 삽입")
+    @Nested
+    class enqueue {
+
+        @DisplayName("원소를 삽입한다.")
+        @Test
+        void success() {
+            // given
+            final Queue<String> queue = new FixedQueue<>(1);
+
+            // when
+            queue.enqueue("data");
+
+            // then
+            assertThat(queue.size()).isOne();
+        }
+
+        @DisplayName("큐가 꽉 찬 상태에서 원소를 삽입하면 예외가 발생한다.")
+        @Test
+        void throwsException_whenQueueIsFull() {
+            // given
+            final Queue<String> fullQueue = new FixedQueue<>(1);
+            fullQueue.enqueue("data");
+
+            // when & then
+            assertThatExceptionOfType(FullQueueException.class)
+                    .isThrownBy(() -> fullQueue.enqueue("data"));
+        }
+    }
+}

--- a/src/test/java/org/example/queue/FixedQueueTest.java
+++ b/src/test/java/org/example/queue/FixedQueueTest.java
@@ -38,4 +38,35 @@ class FixedQueueTest {
                     .isThrownBy(() -> fullQueue.enqueue("data"));
         }
     }
+
+    @DisplayName("가장 먼저 추가된 원소 삭제")
+    @Nested
+    class dequeue {
+
+        @DisplayName("가장 먼저 추가된 원소를 삭제하고 값을 return한다.")
+        @Test
+        void success() {
+            // given
+            final Queue<String> queue = new FixedQueue<>(2);
+            queue.enqueue("data1");
+            queue.enqueue("data2");
+
+            // when
+            final String dequeued = queue.dequeue();
+
+            // then
+            assertThat(dequeued).isEqualTo("data1");
+        }
+
+        @DisplayName("빈 큐의 원소를 삭제하면 예외가 발생한다.")
+        @Test
+        void throwsException_whenQueueIsEmpty() {
+            // given
+            final Queue<String> emptyQueue = new FixedQueue<>(1);
+
+            // when & then
+            assertThatExceptionOfType(EmptyQueueException.class)
+                    .isThrownBy(emptyQueue::dequeue);
+        }
+    }
 }

--- a/src/test/java/org/example/queue/FixedQueueTest.java
+++ b/src/test/java/org/example/queue/FixedQueueTest.java
@@ -2,6 +2,7 @@ package org.example.queue;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -37,6 +38,24 @@ class FixedQueueTest {
             assertThatExceptionOfType(FullQueueException.class)
                     .isThrownBy(() -> fullQueue.enqueue("data"));
         }
+
+        @DisplayName("꽉 찬 큐에서 원소를 삭제한 뒤 다시 원소를 삽입한다.")
+        @Test
+        void afterDequeueFromFullQueue() {
+            // given
+            final Queue<String> queue = new FixedQueue<>(1);
+            queue.enqueue("data1");
+            queue.dequeue();
+
+            // when
+            queue.enqueue("data2");
+
+            // then
+            assertAll(
+                    () -> assertThat(queue.peek()).isEqualTo("data2"),
+                    () -> assertThat(queue.size()).isOne()
+            );
+        }
     }
 
     @DisplayName("가장 먼저 추가된 원소 삭제")
@@ -69,4 +88,36 @@ class FixedQueueTest {
                     .isThrownBy(emptyQueue::dequeue);
         }
     }
+
+    @DisplayName("가장 먼저 추가된 원소 조회")
+    @Nested
+    class peek {
+
+        @DisplayName("가장 먼저 추가된 원소의 값을 조회한다.")
+        @Test
+        void success() {
+            // given
+            final Queue<String> queue = new FixedQueue<>(2);
+            queue.enqueue("data1");
+            queue.enqueue("data2");
+
+            // when
+            final String peeked = queue.peek();
+
+            // then
+            assertThat(peeked).isEqualTo("data1");
+        }
+
+        @DisplayName("빈 큐의 원소를 조회하면 예외가 발생한다.")
+        @Test
+        void throwsException_whenQueueIsEmpty() {
+            // given
+            final Queue<String> emptyQueue = new FixedQueue<>(1);
+
+            // when & then
+            assertThatExceptionOfType(EmptyQueueException.class)
+                    .isThrownBy(emptyQueue::peek);
+        }
+    }
+
 }

--- a/src/test/java/org/example/queue/FlexibleQueueTest.java
+++ b/src/test/java/org/example/queue/FlexibleQueueTest.java
@@ -52,4 +52,35 @@ class FlexibleQueueTest {
                     .isThrownBy(emptyQueue::dequeue);
         }
     }
+
+    @DisplayName("가장 먼저 추가된 원소 조회")
+    @Nested
+    class peek {
+
+        @DisplayName("가장 먼저 추가된 원소의 값을 조회한다.")
+        @Test
+        void success() {
+            // given
+            final Queue<String> queue = new FlexibleQueue<>();
+            queue.enqueue("data1");
+            queue.enqueue("data2");
+
+            // when
+            final String peeked = queue.peek();
+
+            // then
+            assertThat(peeked).isEqualTo("data1");
+        }
+
+        @DisplayName("빈 큐의 값을 조회하면 예외가 발생한다.")
+        @Test
+        void throwsException_whenQueueIsEmpty() {
+            // given
+            final Queue<String> emptyQueue = new FlexibleQueue<>();
+
+            // when & then
+            assertThatExceptionOfType(EmptyQueueException.class)
+                    .isThrownBy(emptyQueue::peek);
+        }
+    }
 }

--- a/src/test/java/org/example/queue/FlexibleQueueTest.java
+++ b/src/test/java/org/example/queue/FlexibleQueueTest.java
@@ -1,0 +1,22 @@
+package org.example.queue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class FlexibleQueueTest {
+
+    @DisplayName("원소를 삽입한다.")
+    @Test
+    void enqueue() {
+        // given
+        final Queue<String> queue = new FlexibleQueue<>();
+
+        // when
+        queue.enqueue("data");
+
+        // then
+        assertThat(queue.size()).isOne();
+    }
+}

--- a/src/test/java/org/example/queue/FlexibleQueueTest.java
+++ b/src/test/java/org/example/queue/FlexibleQueueTest.java
@@ -1,8 +1,10 @@
 package org.example.queue;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class FlexibleQueueTest {
@@ -18,5 +20,36 @@ class FlexibleQueueTest {
 
         // then
         assertThat(queue.size()).isOne();
+    }
+
+    @DisplayName("가장 먼저 추가된 원소 삭제")
+    @Nested
+    class dequeue {
+
+        @DisplayName("가장 먼저 추가된 원소를 삭제하고 값을 반환한다.")
+        @Test
+        void success() {
+            // given
+            final Queue<String> queue = new FlexibleQueue<>();
+            queue.enqueue("data1");
+            queue.enqueue("data2");
+
+            // when
+            final String dequeued = queue.dequeue();
+
+            // then
+            assertThat(dequeued).isEqualTo("data1");
+        }
+
+        @DisplayName("빈 큐의 값을 삭제하면 예외가 발생한다.")
+        @Test
+        void throwsException_whenQueueIsEmpty() {
+            // given
+            final Queue<String> emptyQueue = new FlexibleQueue<>();
+
+            // when & then
+            assertThatExceptionOfType(EmptyQueueException.class)
+                    .isThrownBy(emptyQueue::dequeue);
+        }
     }
 }

--- a/src/test/java/org/example/stack/FixedStackTest.java
+++ b/src/test/java/org/example/stack/FixedStackTest.java
@@ -48,14 +48,15 @@ class FixedStackTest {
         @Test
         void success() {
             // given
-            final Stack<String> stack = new FixedStack<>(1);
-            stack.push("data");
+            final Stack<String> stack = new FixedStack<>(2);
+            stack.push("data1");
+            stack.push("data2");
 
             // when
             final String popped = stack.pop();
 
             // then
-            assertThat(popped).isEqualTo("data");
+            assertThat(popped).isEqualTo("data2");
         }
 
         @DisplayName("빈 스택의 값을 삭제하면 예외가 발생한다..")
@@ -78,14 +79,15 @@ class FixedStackTest {
         @Test
         void success() {
             // given
-            final Stack<String> stack = new FixedStack<>(1);
-            stack.push("data");
+            final Stack<String> stack = new FixedStack<>(2);
+            stack.push("data1");
+            stack.push("data2");
 
             // when
             final String peeked = stack.peek();
 
             // then
-            assertThat(peeked).isEqualTo("data");
+            assertThat(peeked).isEqualTo("data2");
         }
 
         @DisplayName("빈 스택의 값을 조회하면 예외가 발생한다..")


### PR DESCRIPTION
# Queue

`FIFO(First In, First Out)` 원칙을 따르는 선형 자료구조
항상 끝에만 삽입, 항상 앞에서만 조회, 삭제
선입 선출, 발신 순서 그대로 수신해야 하는 경우에 활용
- 프린터 대기열
- 너비 우선 탐색
- 주문 대기열
- Streaming
- Messaging

## 구현

### FixedQueue
array로 구현한 고정 크기 queue

![fixed_queue](https://github.com/YJGwon/implement-data-structures/assets/89305335/8db9aa35-387a-4a89-abef-1667e6e7089c)

양 끝의 두 포인터(first, last)를 순환시키며 처음에 생성한 capacity만큼의 공간을 계속 재사용(포인터 값을 뒤로 이동할 때 마다 모듈러 연산 수행)

#### 시간복잡도
enqueue, dequeue, peek 모두 O(1)

### FlexibleQueue
단방향 순환 linked list로 구현한 가변 크기 queue

![flexible queue](https://github.com/YJGwon/implement-data-structures/assets/89305335/fa3be6e8-a030-4d85-947f-9c41d4b2e8c0)

각 node는 자신의 next만 알고 있고, queue는 tail node를 참조 (tail을 알면 tail.next로 head까지 알 수 있음)
queue가 비어있을 때는 tail이 static singleton 객체인 `empty node`를 참조
그렇지 않을 때에는 `head -> ... -> tail -> head` 와 같이 단방향 circular linked list 형태

#### 시간복잡도
enqueue, dequeue, peek 모두 O(1)
