### PR TITLE
feat: HashTable 구현

### DIFF
--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -1,7 +1,0 @@
-package org.example;
-
-public class Main {
-    public static void main(String[] args) {
-        System.out.println("Hello world!");
-    }
-}

--- a/src/main/java/org/example/hashtable/Entry.java
+++ b/src/main/java/org/example/hashtable/Entry.java
@@ -1,0 +1,24 @@
+package org.example.hashtable;
+
+public class Entry<K, V> {
+
+    private final K key;
+    private final V value;
+
+    public Entry(final K key, final V value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public boolean isKey(final K key) {
+        return this.key.equals(key);
+    }
+
+    public K getKey() {
+        return key;
+    }
+
+    public V getValue() {
+        return value;
+    }
+}

--- a/src/main/java/org/example/hashtable/HashTable.java
+++ b/src/main/java/org/example/hashtable/HashTable.java
@@ -1,0 +1,19 @@
+package org.example.hashtable;
+
+import java.util.Collection;
+import java.util.Set;
+
+public interface HashTable<K, V> {
+
+    void put(K key, V value);
+
+    V remove(K key);
+
+    V get(K key);
+
+    boolean isEmpty();
+
+    Set<K> keys();
+
+    Collection<V> values();
+}

--- a/src/main/java/org/example/hashtable/LinearProbingHashTable.java
+++ b/src/main/java/org/example/hashtable/LinearProbingHashTable.java
@@ -1,0 +1,77 @@
+package org.example.hashtable;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Set;
+
+public class LinearProbingHashTable<K, V> implements HashTable<K, V> {
+
+    private static final int INITIAL_SIZE = 31;
+
+    private Entry<K, V>[] bucket;
+    private int numberOfElements;
+
+    public LinearProbingHashTable() {
+        this.bucket = (Entry<K, V>[]) new Entry[INITIAL_SIZE];
+        this.numberOfElements = 0;
+    }
+
+    @Override
+    public void put(final K key, final V value) {
+        final int hash = Objects.hash(key) % bucket.length;
+        final Entry<K, V> entryToAdd = new Entry<>(key, value);
+
+        int index = hash;
+        while (index < bucket.length) {
+            final Entry<K, V> entry = bucket[index];
+            if (entry == null) {
+                addNewEntry(entryToAdd, index);
+                return;
+            }
+
+            if (entry.isKey(key)) {
+                overwriteValue(entryToAdd, index);
+                return;
+            }
+            index++;
+        }
+    }
+
+    @Override
+    public V remove(final K key) {
+        return null;
+    }
+
+    @Override
+    public V get(final K key) {
+        return null;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+
+    @Override
+    public Set<K> keys() {
+        return null;
+    }
+
+    @Override
+    public Collection<V> values() {
+        return null;
+    }
+
+    public int size() {
+        return numberOfElements;
+    }
+
+    private void addNewEntry(final Entry<K, V> entryToAdd, final int index) {
+        bucket[index] = entryToAdd;
+        numberOfElements++;
+    }
+
+    private void overwriteValue(final Entry<K, V> entryToAdd, final int index) {
+        bucket[index] = entryToAdd;
+    }
+}

--- a/src/main/java/org/example/hashtable/LinearProbingHashTable.java
+++ b/src/main/java/org/example/hashtable/LinearProbingHashTable.java
@@ -18,10 +18,9 @@ public class LinearProbingHashTable<K, V> implements HashTable<K, V> {
 
     @Override
     public void put(final K key, final V value) {
-        final int hash = Objects.hash(key) % bucket.length;
         final Entry<K, V> entryToAdd = new Entry<>(key, value);
 
-        int index = hash;
+        int index = Objects.hash(key) % bucket.length;
         while (index < bucket.length) {
             final Entry<K, V> entry = bucket[index];
             if (entry == null) {
@@ -35,6 +34,7 @@ public class LinearProbingHashTable<K, V> implements HashTable<K, V> {
             }
             index++;
         }
+        // TODO: check load factor and resize bucket
     }
 
     @Override
@@ -44,6 +44,19 @@ public class LinearProbingHashTable<K, V> implements HashTable<K, V> {
 
     @Override
     public V get(final K key) {
+        int index = Objects.hash(key) % bucket.length;
+        while (index < bucket.length) {
+            final Entry<K, V> entry = bucket[index];
+            if (entry == null) {
+                break;
+            }
+
+            if (entry.isKey(key)) {
+                return entry.getValue();
+            }
+            index++;
+        }
+
         return null;
     }
 
@@ -74,4 +87,6 @@ public class LinearProbingHashTable<K, V> implements HashTable<K, V> {
     private void overwriteValue(final Entry<K, V> entryToAdd, final int index) {
         bucket[index] = entryToAdd;
     }
+
+
 }

--- a/src/main/java/org/example/hashtable/LinearProbingHashTable.java
+++ b/src/main/java/org/example/hashtable/LinearProbingHashTable.java
@@ -19,21 +19,11 @@ public class LinearProbingHashTable<K, V> implements HashTable<K, V> {
     @Override
     public void put(final K key, final V value) {
         final Entry<K, V> entryToAdd = new Entry<>(key, value);
-
-        int index = Objects.hash(key) % bucket.length;
-        while (index < bucket.length) {
-            final Entry<K, V> entry = bucket[index];
-            if (entry == null) {
-                addNewEntry(entryToAdd, index);
-                return;
-            }
-
-            if (entry.isKey(key)) {
-                overwriteValue(entryToAdd, index);
-                return;
-            }
-            index++;
+        final int availableIndex = findAvailableIndex(key);
+        if (bucket[availableIndex] == null) {
+            numberOfElements++;
         }
+        bucket[availableIndex] = entryToAdd;
         // TODO: check load factor and resize bucket
     }
 
@@ -44,20 +34,11 @@ public class LinearProbingHashTable<K, V> implements HashTable<K, V> {
 
     @Override
     public V get(final K key) {
-        int index = Objects.hash(key) % bucket.length;
-        while (index < bucket.length) {
-            final Entry<K, V> entry = bucket[index];
-            if (entry == null) {
-                break;
-            }
-
-            if (entry.isKey(key)) {
-                return entry.getValue();
-            }
-            index++;
+        final Entry<K, V> entry = bucket[findAvailableIndex(key)];
+        if (entry == null) {
+            return null;
         }
-
-        return null;
+        return entry.getValue();
     }
 
     @Override
@@ -79,14 +60,24 @@ public class LinearProbingHashTable<K, V> implements HashTable<K, V> {
         return numberOfElements;
     }
 
-    private void addNewEntry(final Entry<K, V> entryToAdd, final int index) {
-        bucket[index] = entryToAdd;
-        numberOfElements++;
+    // FIXME: may return bucket.length if no bucket available - but will be fixed after adding dynamic resizing
+    private int findAvailableIndex(final K key) {
+        int index = hash(key);
+        while (index < bucket.length) {
+            final Entry<K, V> entry = bucket[index];
+            if (entry == null) {
+                break;
+            }
+
+            if (entry.isKey(key)) {
+                return index;
+            }
+            index++;
+        }
+        return index;
     }
 
-    private void overwriteValue(final Entry<K, V> entryToAdd, final int index) {
-        bucket[index] = entryToAdd;
+    private int hash(final K key) {
+        return Objects.hash(key) % bucket.length;
     }
-
-
 }

--- a/src/main/java/org/example/hashtable/LinearProbingHashTable.java
+++ b/src/main/java/org/example/hashtable/LinearProbingHashTable.java
@@ -1,8 +1,10 @@
 package org.example.hashtable;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class LinearProbingHashTable<K, V> implements HashTable<K, V> {
 
@@ -51,17 +53,23 @@ public class LinearProbingHashTable<K, V> implements HashTable<K, V> {
 
     @Override
     public boolean isEmpty() {
-        return false;
+        return numberOfElements == 0;
     }
 
     @Override
     public Set<K> keys() {
-        return null;
+        return Arrays.stream(bucket)
+                .filter(Objects::nonNull)
+                .map(Entry::getKey)
+                .collect(Collectors.toSet());
     }
 
     @Override
     public Collection<V> values() {
-        return null;
+        return Arrays.stream(bucket)
+                .filter(Objects::nonNull)
+                .map(Entry::getValue)
+                .collect(Collectors.toList());
     }
 
     public int size() {

--- a/src/main/java/org/example/hashtable/LinearProbingHashTable.java
+++ b/src/main/java/org/example/hashtable/LinearProbingHashTable.java
@@ -78,8 +78,9 @@ public class LinearProbingHashTable<K, V> implements HashTable<K, V> {
         return numberOfElements;
     }
 
+    // FIXME: may execute in infinite loop - but will be fixed after adding dynamic resizing
     private void rearrangeFollowingEntries(final int targetIndex) {
-        int indexToRearrange = targetIndex + 1;
+        int indexToRearrange = (targetIndex + 1) % bucket.length;
         while (indexToRearrange < bucket.length) {
             final Entry<K, V> entryToRearrange = bucket[indexToRearrange];
             if (entryToRearrange == null) { // no more following entries
@@ -90,15 +91,14 @@ public class LinearProbingHashTable<K, V> implements HashTable<K, V> {
                 break;
             }
             bucket[availableIndex] = entryToRearrange;
-            indexToRearrange++;
+            indexToRearrange = (indexToRearrange + 1) % bucket.length;
         }
     }
 
-
-    // FIXME: may return bucket.length if no bucket available - but will be fixed after adding dynamic resizing
+    // FIXME: may execute in infinite loop - but will be fixed after adding dynamic resizing
     private int findAvailableIndex(final K key) {
         int index = hash(key);
-        while (index < bucket.length) {
+        while (true) {
             final Entry<K, V> entry = bucket[index];
             if (entry == null) {
                 break;
@@ -107,7 +107,7 @@ public class LinearProbingHashTable<K, V> implements HashTable<K, V> {
             if (entry.isKey(key)) {
                 return index;
             }
-            index++;
+            index = (index + 1) % bucket.length;
         }
         return index;
     }

--- a/src/main/java/org/example/hashtable/LinearProbingHashTable.java
+++ b/src/main/java/org/example/hashtable/LinearProbingHashTable.java
@@ -37,7 +37,9 @@ public class LinearProbingHashTable<K, V> implements HashTable<K, V> {
             return null;
         }
         bucket[targetIndex] = null;
+        rearrangeFollowingEntries(targetIndex);
         numberOfElements--;
+
         return entryToRemove.getValue();
     }
 
@@ -75,6 +77,23 @@ public class LinearProbingHashTable<K, V> implements HashTable<K, V> {
     public int size() {
         return numberOfElements;
     }
+
+    private void rearrangeFollowingEntries(final int targetIndex) {
+        int indexToRearrange = targetIndex + 1;
+        while (indexToRearrange < bucket.length) {
+            final Entry<K, V> entryToRearrange = bucket[indexToRearrange];
+            if (entryToRearrange == null) { // no more following entries
+                break;
+            }
+            final int availableIndex = findAvailableIndex(entryToRearrange.getKey());
+            if (indexToRearrange == availableIndex) { // already in right place
+                break;
+            }
+            bucket[availableIndex] = entryToRearrange;
+            indexToRearrange++;
+        }
+    }
+
 
     // FIXME: may return bucket.length if no bucket available - but will be fixed after adding dynamic resizing
     private int findAvailableIndex(final K key) {

--- a/src/main/java/org/example/hashtable/LinearProbingHashTable.java
+++ b/src/main/java/org/example/hashtable/LinearProbingHashTable.java
@@ -29,12 +29,20 @@ public class LinearProbingHashTable<K, V> implements HashTable<K, V> {
 
     @Override
     public V remove(final K key) {
-        return null;
+        final int targetIndex = findAvailableIndex(key);
+        final Entry<K, V> entryToRemove = bucket[targetIndex];
+        if (entryToRemove == null) {
+            return null;
+        }
+        bucket[targetIndex] = null;
+        numberOfElements--;
+        return entryToRemove.getValue();
     }
 
     @Override
     public V get(final K key) {
-        final Entry<K, V> entry = bucket[findAvailableIndex(key)];
+        final int targetIndex = findAvailableIndex(key);
+        final Entry<K, V> entry = bucket[targetIndex];
         if (entry == null) {
             return null;
         }

--- a/src/test/java/org/example/hashtable/LinearProbingHashTableTest.java
+++ b/src/test/java/org/example/hashtable/LinearProbingHashTableTest.java
@@ -1,0 +1,44 @@
+package org.example.hashtable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class LinearProbingHashTableTest {
+
+    @DisplayName("해시 테이블에 키와 값 저장")
+    @Nested
+    class put {
+
+        @DisplayName("할 수 있다.")
+        @Test
+        void success() {
+            // given
+            final LinearProbingHashTable<String, String> hashTable = new LinearProbingHashTable<>();
+
+            // when
+            hashTable.put("key", "value");
+
+            // then
+            assertThat(hashTable.size()).isOne();
+        }
+
+        @DisplayName("할 때, 이미 존재하는 키면 원래의 값을 덮어쓴다.")
+        @Test
+        void overwriteValue_whenKeyExists() {
+            // given
+            final LinearProbingHashTable<String, String> hashTable = new LinearProbingHashTable<>();
+
+            final String existingKey = "key";
+            hashTable.put(existingKey, "value");
+
+            // when
+            hashTable.put(existingKey, "new value");
+
+            // then
+            assertThat(hashTable.size()).isOne();
+        }
+    }
+}

--- a/src/test/java/org/example/hashtable/LinearProbingHashTableTest.java
+++ b/src/test/java/org/example/hashtable/LinearProbingHashTableTest.java
@@ -1,6 +1,7 @@
 package org.example.hashtable;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -75,6 +76,45 @@ class LinearProbingHashTableTest {
 
             // then
             assertThat(actual).isNull();
+        }
+    }
+
+    @DisplayName("키에 해당하는 값 삭제")
+    @Nested
+    class remove {
+
+        @DisplayName("하면 삭제된 값을 반환한다.")
+        @Test
+        void success() {
+            // given
+            final LinearProbingHashTable<String, String> hashTable = new LinearProbingHashTable<>();
+
+            final String key = "key";
+            final String expected = "value";
+
+            hashTable.put(key, expected);
+
+            // when
+            final String removed = hashTable.remove(key);
+
+            // then
+            assertAll(
+                    () -> assertThat(removed).isEqualTo(expected),
+                    () -> assertThat(hashTable.size()).isZero()
+            );
+        }
+
+        @DisplayName("할 때, 존재하지 않는 키이면 null을 반환한다.")
+        @Test
+        void returnsNull_whenKeyDoesNotExist() {
+            // given
+            final LinearProbingHashTable<String, String> hashTable = new LinearProbingHashTable<>();
+
+            // when
+            final String removed = hashTable.remove("key");
+
+            // then
+            assertThat(removed).isNull();
         }
     }
 }

--- a/src/test/java/org/example/hashtable/LinearProbingHashTableTest.java
+++ b/src/test/java/org/example/hashtable/LinearProbingHashTableTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 class LinearProbingHashTableTest {
 
-    @DisplayName("해시 테이블에 키와 값 저장")
+    @DisplayName("키와 값 저장")
     @Nested
     class put {
 
@@ -39,6 +39,42 @@ class LinearProbingHashTableTest {
 
             // then
             assertThat(hashTable.size()).isOne();
+        }
+    }
+
+    @DisplayName("키에 해당하는 값 조회")
+    @Nested
+    class get {
+
+        @DisplayName("할 수 있다.")
+        @Test
+        void success() {
+            // given
+            final LinearProbingHashTable<String, String> hashTable = new LinearProbingHashTable<>();
+
+            final String key = "key";
+            final String expected = "value";
+
+            hashTable.put(key, expected);
+
+            // when
+            final String actual = hashTable.get(key);
+
+            // then
+            assertThat(actual).isEqualTo(expected);
+        }
+
+        @DisplayName("할 때, 존재하지 않는 키이면 null을 반환한다.")
+        @Test
+        void returnsNull_whenKeyDoesNotExist() {
+            // given
+            final LinearProbingHashTable<String, String> hashTable = new LinearProbingHashTable<>();
+
+            // when
+            final String actual = hashTable.get("key");
+
+            // then
+            assertThat(actual).isNull();
         }
     }
 }

--- a/src/test/java/org/example/hashtable/LinearProbingHashTableTest.java
+++ b/src/test/java/org/example/hashtable/LinearProbingHashTableTest.java
@@ -3,6 +3,8 @@ package org.example.hashtable;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import java.util.Collection;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -116,5 +118,45 @@ class LinearProbingHashTableTest {
             // then
             assertThat(removed).isNull();
         }
+    }
+
+    @DisplayName("저장된 키의 목록을 조회한다.")
+    @Test
+    void keys() {
+        // given
+        final LinearProbingHashTable<String, String> hashTable = new LinearProbingHashTable<>();
+        final String key1 = "key1";
+        final String key2 = "key2";
+        final String key3 = "key3";
+
+        hashTable.put(key1, "value");
+        hashTable.put(key2, "value");
+        hashTable.put(key3, "value");
+
+        // when
+        final Set<String> keys = hashTable.keys();
+
+        // then
+        assertThat(keys).containsExactlyInAnyOrder(key1, key2, key3);
+    }
+
+    @DisplayName("저장된 값의 목록을 조회한다.")
+    @Test
+    void values() {
+        // given
+        final LinearProbingHashTable<String, String> hashTable = new LinearProbingHashTable<>();
+
+        final String value1 = "value1";
+        final String value2 = "value2";
+
+        hashTable.put("key1", value1);
+        hashTable.put("key2", value2);
+        hashTable.put("key3", value2);
+
+        // when
+        final Collection<String> values = hashTable.values();
+
+        // then
+        assertThat(values).containsExactlyInAnyOrder(value1, value2, value2);
     }
 }

--- a/src/test/java/org/example/hashtable/LinearProbingHashTableTest.java
+++ b/src/test/java/org/example/hashtable/LinearProbingHashTableTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -120,6 +121,34 @@ class LinearProbingHashTableTest {
         }
     }
 
+    @DisplayName("해시가 충돌해도 값을 저장할 수 있다.")
+    @Test
+    void collision() {
+        // given
+        final LinearProbingHashTable<FixedHashKey, String> hashTable = new LinearProbingHashTable<>();
+
+        final FixedHashKey key1 = new FixedHashKey(1);
+        final String value1 = "one";
+
+        final FixedHashKey key2 = new FixedHashKey(2);
+        final String value2 = "two";
+
+        hashTable.put(key1, value1);
+        hashTable.put(key2, value2);
+
+        // when
+        final String actual1 = hashTable.get(key1);
+        final String actual2 = hashTable.get(key2);
+
+        // then
+        assertAll(
+                () -> assertThat(Objects.hash(key1)).isEqualTo(Objects.hash(key2)), // hash collision
+                () -> assertThat(key1).isNotEqualTo(key2), // but not equals
+                () -> assertThat(actual1).isEqualTo(value1),
+                () -> assertThat(actual2).isEqualTo(value2)
+        );
+    }
+
     @DisplayName("저장된 키의 목록을 조회한다.")
     @Test
     void keys() {
@@ -158,5 +187,25 @@ class LinearProbingHashTableTest {
 
         // then
         assertThat(values).containsExactlyInAnyOrder(value1, value2, value2);
+    }
+
+    private static class FixedHashKey {
+
+        final int value;
+
+        private FixedHashKey(final int value) {
+            this.value = value;
+        }
+
+        @Override
+        public int hashCode() {
+            return 0;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            final FixedHashKey fixedHashKey = (FixedHashKey) o;
+            return value == fixedHashKey.value;
+        }
     }
 }

--- a/src/test/java/org/example/linkedlist/LinkedListTest.java
+++ b/src/test/java/org/example/linkedlist/LinkedListTest.java
@@ -45,11 +45,11 @@ class LinkedListTest {
         );
     }
 
-    @DisplayName("특정 위치 원소 반환")
+    @DisplayName("특정 위치 원소 조회")
     @Nested
     class get {
 
-        @DisplayName("특정 위치의 원소를 반환한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -64,7 +64,7 @@ class LinkedListTest {
             assertThat(found).isEqualTo("data2");
         }
 
-        @DisplayName("인덱스가 범위를 벗어나면 예외가 발생한다.")
+        @DisplayName("할 때, 인덱스가 범위를 벗어나면 예외가 발생한다.")
         @Test
         void throwsException_whenIndexOutOfBound() {
             // given
@@ -81,7 +81,7 @@ class LinkedListTest {
     @Nested
     class add {
 
-        @DisplayName("특정 위치에 원소를 추가한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -96,7 +96,7 @@ class LinkedListTest {
             assertThat(linkedList.get(1)).isEqualTo("data3");
         }
 
-        @DisplayName("인덱스가 범위를 벗어나면 예외가 발생한다.")
+        @DisplayName("할 때, 인덱스가 범위를 벗어나면 예외가 발생한다.")
         @Test
         void throwsException_whenIndexOutOfBound() {
             // given
@@ -112,7 +112,7 @@ class LinkedListTest {
     @Nested
     class set {
 
-        @DisplayName("특정 위치의 원소를 변경한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -127,7 +127,7 @@ class LinkedListTest {
             assertThat(linkedList.getLast()).isEqualTo("changed");
         }
 
-        @DisplayName("인덱스가 범위를 벗어나면 예외가 발생한다.")
+        @DisplayName("할 때, 인덱스가 범위를 벗어나면 예외가 발생한다.")
         @Test
         void throwsException_whenIndexOutOfBound() {
             // given
@@ -143,7 +143,7 @@ class LinkedListTest {
     @Nested
     class removeFirst {
 
-        @DisplayName("맨 앞의 원소를 삭제한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -161,7 +161,7 @@ class LinkedListTest {
             );
         }
 
-        @DisplayName("원소가 존재하지 않으면 예외가 발생한다.")
+        @DisplayName("할 때, 원소가 존재하지 않으면 예외가 발생한다.")
         @Test
         void throwsException_whenNoElement() {
             // given
@@ -177,7 +177,7 @@ class LinkedListTest {
     @Nested
     class removeLast {
 
-        @DisplayName("맨 뒤의 원소를 삭제한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -195,7 +195,7 @@ class LinkedListTest {
             );
         }
 
-        @DisplayName("원소가 존재하지 않으면 예외가 발생한다.")
+        @DisplayName("할 때, 원소가 존재하지 않으면 예외가 발생한다.")
         @Test
         void throwsException_whenNoElement() {
             // given
@@ -211,7 +211,7 @@ class LinkedListTest {
     @Nested
     class remove {
 
-        @DisplayName("특정 위치의 원소를 삭제한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -230,7 +230,7 @@ class LinkedListTest {
             );
         }
 
-        @DisplayName("원소가 존재하지 않으면 예외가 발생한다.")
+        @DisplayName("할 때, 원소가 존재하지 않으면 예외가 발생한다.")
         @Test
         void throwsException_whenIndexOutOfBound() {
             // given

--- a/src/test/java/org/example/queue/FixedQueueTest.java
+++ b/src/test/java/org/example/queue/FixedQueueTest.java
@@ -14,7 +14,7 @@ class FixedQueueTest {
     @Nested
     class enqueue {
 
-        @DisplayName("원소를 삽입한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -27,7 +27,7 @@ class FixedQueueTest {
             assertThat(queue.size()).isOne();
         }
 
-        @DisplayName("큐가 꽉 찬 상태에서 원소를 삽입하면 예외가 발생한다.")
+        @DisplayName("할 때, 큐가 꽉 차있으면 예외가 발생한다.")
         @Test
         void throwsException_whenQueueIsFull() {
             // given
@@ -39,7 +39,7 @@ class FixedQueueTest {
                     .isThrownBy(() -> fullQueue.enqueue("data"));
         }
 
-        @DisplayName("꽉 찬 큐에서 원소를 삭제한 뒤 다시 원소를 삽입한다.")
+        @DisplayName("을 꽉 찬 큐에서 원소를 삭제한 뒤 다시 할 수 있다.")
         @Test
         void afterDequeueFromFullQueue() {
             // given
@@ -62,7 +62,7 @@ class FixedQueueTest {
     @Nested
     class dequeue {
 
-        @DisplayName("가장 먼저 추가된 원소를 삭제하고 값을 return한다.")
+        @DisplayName("하면 삭제된 값을 return한다.")
         @Test
         void success() {
             // given
@@ -77,7 +77,7 @@ class FixedQueueTest {
             assertThat(dequeued).isEqualTo("data1");
         }
 
-        @DisplayName("빈 큐의 원소를 삭제하면 예외가 발생한다.")
+        @DisplayName("할 때 큐가 비어있으면 예외가 발생한다.")
         @Test
         void throwsException_whenQueueIsEmpty() {
             // given
@@ -93,7 +93,7 @@ class FixedQueueTest {
     @Nested
     class peek {
 
-        @DisplayName("가장 먼저 추가된 원소의 값을 조회한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -108,7 +108,7 @@ class FixedQueueTest {
             assertThat(peeked).isEqualTo("data1");
         }
 
-        @DisplayName("빈 큐의 원소를 조회하면 예외가 발생한다.")
+        @DisplayName("할 때 큐가 비어있으면 예외가 발생한다.")
         @Test
         void throwsException_whenQueueIsEmpty() {
             // given

--- a/src/test/java/org/example/queue/FlexibleQueueTest.java
+++ b/src/test/java/org/example/queue/FlexibleQueueTest.java
@@ -26,7 +26,7 @@ class FlexibleQueueTest {
     @Nested
     class dequeue {
 
-        @DisplayName("가장 먼저 추가된 원소를 삭제하고 값을 반환한다.")
+        @DisplayName("하면 삭제된 값을 반환한다.")
         @Test
         void success() {
             // given
@@ -41,7 +41,7 @@ class FlexibleQueueTest {
             assertThat(dequeued).isEqualTo("data1");
         }
 
-        @DisplayName("빈 큐의 값을 삭제하면 예외가 발생한다.")
+        @DisplayName("할 때 큐가 비어있으면 예외가 발생한다.")
         @Test
         void throwsException_whenQueueIsEmpty() {
             // given
@@ -57,7 +57,7 @@ class FlexibleQueueTest {
     @Nested
     class peek {
 
-        @DisplayName("가장 먼저 추가된 원소의 값을 조회한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -72,7 +72,7 @@ class FlexibleQueueTest {
             assertThat(peeked).isEqualTo("data1");
         }
 
-        @DisplayName("빈 큐의 값을 조회하면 예외가 발생한다.")
+        @DisplayName("할 때 큐가 비어있으면 예외가 발생한다.")
         @Test
         void throwsException_whenQueueIsEmpty() {
             // given

--- a/src/test/java/org/example/stack/FixedStackTest.java
+++ b/src/test/java/org/example/stack/FixedStackTest.java
@@ -14,7 +14,7 @@ class FixedStackTest {
     @Nested
     class push {
 
-        @DisplayName("고정 크기 스택의 마지막에 원소를 삽입한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -27,7 +27,7 @@ class FixedStackTest {
             assertThat(stack.size()).isOne();
         }
 
-        @DisplayName("스택이 가득 찬 상태에서 원소를 삽입하면 예외가 발생한다.")
+        @DisplayName("할 때 스택이 가득 차있으면 예외가 발생한다.")
         @Test
         void throwsException_whenStackIsFull() {
             // given
@@ -44,7 +44,7 @@ class FixedStackTest {
     @Nested
     class pop {
 
-        @DisplayName("마지막에 삽입된 원소를 삭제하고 값을 반환한다.")
+        @DisplayName("하면 삭제된 값을 반환한다.")
         @Test
         void success() {
             // given
@@ -59,7 +59,7 @@ class FixedStackTest {
             assertThat(popped).isEqualTo("data2");
         }
 
-        @DisplayName("빈 스택의 값을 삭제하면 예외가 발생한다..")
+        @DisplayName("할 때 스택이 비어있으면 예외가 발생한다.")
         @Test
         void throwsException_whenStackIsEmpty() {
             // given
@@ -75,7 +75,7 @@ class FixedStackTest {
     @Nested
     class peek {
 
-        @DisplayName("마지막에 삽임된 원소의 값을 조회한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -90,7 +90,7 @@ class FixedStackTest {
             assertThat(peeked).isEqualTo("data2");
         }
 
-        @DisplayName("빈 스택의 값을 조회하면 예외가 발생한다..")
+        @DisplayName("할 때 스택이 비어있으면 예외가 발생한다.")
         @Test
         void throwsException_whenStackIsEmpty() {
             // given

--- a/src/test/java/org/example/stack/FlexibleStackTest.java
+++ b/src/test/java/org/example/stack/FlexibleStackTest.java
@@ -27,7 +27,7 @@ class FlexibleStackTest {
     @Nested
     class pop {
 
-        @DisplayName("마지막에 삽입된 원소를 삭제하고 값을 반환한다.")
+        @DisplayName("하면 삭제된 값을 반환한다.")
         @Test
         void success() {
             // given
@@ -41,7 +41,7 @@ class FlexibleStackTest {
             assertThat(popped).isEqualTo("data");
         }
 
-        @DisplayName("빈 스택에서 원소를 삭제하면 예외가 발생한다.")
+        @DisplayName("할 때 스택이 비어있으면 예외가 발생한다.")
         @Test
         void throwsException_whenStackIsEmpty() {
             // given
@@ -57,7 +57,7 @@ class FlexibleStackTest {
     @Nested
     class peek {
 
-        @DisplayName("마지막에 삽입된 원소의 값을 조회한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -71,7 +71,7 @@ class FlexibleStackTest {
             assertThat(peeked).isEqualTo("data");
         }
 
-        @DisplayName("빈 스택에서 원소를 조회하면 예외가 발생한다.")
+        @DisplayName("할 때 스택이 비어있으면 예외가 발생한다.")
         @Test
         void throwsException_whenStackIsEmpty() {
             // given


### PR DESCRIPTION
# Hash Table

키와 값의 쌍으로 이뤄진 데이터의 리스트
키를 hashing한 값을 index로 사용해서 조회, 삽입, 삭제 처리 -> O(1)

## 충돌 해결

#### hash 충돌
서로 다른 두 값의 hash 결과가 같아 data를 저장하려는 위치에 이미 다른 data가 존재하는 것
hash table 공간은 한정적이기 때문에 충돌은 필연적으로 발생함
따라서 이 충돌을 해결해야 한다.

### Separate Chaning
hash table 내부의 cell에 하나의 값을 저장하지 않고 여러 값을 선형 자료 구조로 저장하는 방법
충돌이 일어나면 선형 자료구조에 추가

### Open Addressing
충돌이 일어났을 때 비어있는 다른 공간을 대신 사용하는 방법(추가 공간 사용 X)
빈 자리가 생길 때 까지 해시 값 계속 생성

#### Linear Probing
충돌 발생한 cell의 다음 위치에 저장하는 방법
특정 영역에 key가 몰리면 탐색 횟수 증가하여 성능 저하

#### Quadratic Probing
특정 영역에 key가 몰리는 현상 보완
다음 cell을 찾을 때 1칸씩 이동하지 않고 n^2으로 이동
같은 hash값에 충돌이 몰릴 경우 성능 저하

#### Double Hasing
2개의 해시 함수 사용하여 중복을 줄이는 방법
고정 길이 hash값 반환하는 함수 + 충돌 시 기존 위치에서 얼만큼의 보폭으로 jump할지 반환하는 함수
두 함수의 hash 로직을 다르게 작성 -> 충돌 확률 극히 드물게 됨

## 구현

### LinearProbingHashTable
충돌을 Linear Probing 방식으로 해결

> 동적 resizing 구현 필요

![linear-probing-hash-table](https://github.com/YJGwon/implement-data-structures/assets/89305335/071ba1a7-8663-445b-967d-6ab8a6621cce)

충돌 발생 시 빈 슬롯이나 key 값이 같은 슬롯이 나타날 때 까지 1칸씩 선형 탐색
조회, 삽입, 삭제 모두 같은 탐색 과정 필요
삭제의 경우 연속된 충돌 entry 중 중간 entry가 삭제되었을 경우 gap 공간이 생김 -> entry 재조정 필요

#### 시간복잡도
- 충돌 없을 경우 조회, 삽입, 삭제 모두 O(1)
- 충돌 발생할 경우 조회, 삽입, 삭제 모두 O(n), n = 충돌 일어난 만큼

